### PR TITLE
Update package-lock.json; npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@actions-rs/core",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1160,9 +1160,9 @@
             }
         },
         "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+            "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
             "dev": true,
             "optional": true
         },
@@ -2476,9 +2476,9 @@
             "dev": true
         },
         "handlebars": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-            "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+            "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",


### PR DESCRIPTION
Looks like the `package-lock.json` file didn't get updated for the `0.0.4` release?

This also fixes the npm security warning.