### PR TITLE
Update dependencies to enable noImplicitAny

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,31 +15,12 @@
             "integrity": "sha512-nvFkxwiicvpzNiCBF4wFBDfnBvi7xp/as7LE1hBxBxKG2L29+gkIPBiLKMVORL+Hg3JNf07AKRfl0V5djoypjQ=="
         },
         "@actions/github": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@actions/github/-/github-1.1.0.tgz",
-            "integrity": "sha512-cHf6PyoNMdei13jEdGPhKprIMFmjVVW/dnM5/9QmQDJ1ZTaGVyezUSCUIC/ySNLRvDUpeFwPYMdThSEJldSbUw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-2.0.0.tgz",
+            "integrity": "sha512-sNpZ5dJyJyfJIO5lNYx8r/Gha4Tlm8R0MLO2cBkGdOnAAEn3t1M/MHVcoBhY/VPfjGVe5RNAUPz+6INrViiUPA==",
             "requires": {
-                "@octokit/graphql": "^2.0.1",
+                "@octokit/graphql": "^4.3.1",
                 "@octokit/rest": "^16.15.0"
-            },
-            "dependencies": {
-                "@octokit/graphql": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.1.3.tgz",
-                    "integrity": "sha512-XoXJqL2ondwdnMIW3wtqJWEwcBfKk37jO/rYkoxNPEVeLBDGsGO1TCWggrAlq3keGt/O+C/7VepXnukUxwt5vA==",
-                    "requires": {
-                        "@octokit/request": "^5.0.0",
-                        "universal-user-agent": "^2.0.3"
-                    }
-                },
-                "universal-user-agent": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
-                    "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
-                    "requires": {
-                        "os-name": "^3.0.0"
-                    }
-                }
             }
         },
         "@actions/io": {
@@ -454,91 +435,41 @@
                 "@types/yargs": "^13.0.0"
             }
         },
-        "@octokit/endpoint": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.4.0.tgz",
-            "integrity": "sha512-DWTNgEKg5KXzvNjKTzcFTnkZiL7te6pQxxumvxPjyjDpcY5V3xzywnNu1WVqySY3Ct1flF/kAoyDdZos6acq3Q==",
-            "requires": {
-                "is-plain-object": "^3.0.0",
-                "universal-user-agent": "^4.0.0"
-            },
-            "dependencies": {
-                "is-plain-object": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-                    "requires": {
-                        "isobject": "^4.0.0"
-                    }
-                },
-                "isobject": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-                },
-                "universal-user-agent": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-                    "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-                    "requires": {
-                        "os-name": "^3.1.0"
-                    }
-                }
-            }
-        },
         "@octokit/graphql": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-2.0.1.tgz",
-            "integrity": "sha512-IBNr05yBYqffy9L37Vv3/5xQMw+swmYFtMsuwqUA5vSEUr+s/POf8DOpCaTtS8f7e9k+cEuKLC5AbOoXkdZZOA==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
+            "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
             "requires": {
-                "@octokit/request": "^2.1.2"
+                "@octokit/request": "^5.3.0",
+                "@octokit/types": "^2.0.0",
+                "universal-user-agent": "^4.0.0"
             },
             "dependencies": {
                 "@octokit/endpoint": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz",
-                    "integrity": "sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==",
+                    "version": "5.5.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
+                    "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
                     "requires": {
-                        "deepmerge": "3.2.0",
-                        "is-plain-object": "^2.0.4",
-                        "universal-user-agent": "^2.0.1",
-                        "url-template": "^2.0.8"
+                        "@octokit/types": "^2.0.0",
+                        "is-plain-object": "^3.0.0",
+                        "universal-user-agent": "^4.0.0"
                     }
                 },
                 "@octokit/request": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz",
-                    "integrity": "sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==",
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+                    "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
                     "requires": {
-                        "@octokit/endpoint": "^3.2.0",
-                        "deprecation": "^1.0.1",
-                        "is-plain-object": "^2.0.4",
+                        "@octokit/endpoint": "^5.5.0",
+                        "@octokit/request-error": "^1.0.1",
+                        "@octokit/types": "^2.0.0",
+                        "deprecation": "^2.0.0",
+                        "is-plain-object": "^3.0.0",
                         "node-fetch": "^2.3.0",
                         "once": "^1.4.0",
-                        "universal-user-agent": "^2.0.1"
+                        "universal-user-agent": "^4.0.0"
                     }
                 },
-                "deprecation": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
-                    "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg=="
-                }
-            }
-        },
-        "@octokit/request": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
-            "integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
-            "requires": {
-                "@octokit/endpoint": "^5.1.0",
-                "@octokit/request-error": "^1.0.1",
-                "deprecation": "^2.0.0",
-                "is-plain-object": "^3.0.0",
-                "node-fetch": "^2.3.0",
-                "once": "^1.4.0",
-                "universal-user-agent": "^4.0.0"
-            },
-            "dependencies": {
                 "is-plain-object": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
@@ -551,14 +482,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
                     "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-                },
-                "universal-user-agent": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-                    "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
-                    "requires": {
-                        "os-name": "^3.1.0"
-                    }
                 }
             }
         },
@@ -737,6 +660,12 @@
             "version": "12.12.14",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
             "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
+        },
+        "@types/semver": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.0.tgz",
+            "integrity": "sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==",
+            "dev": true
         },
         "@types/stack-utils": {
             "version": "1.0.1",
@@ -1590,11 +1519,6 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
-        },
-        "deepmerge": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-            "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
         },
         "define-properties": {
             "version": "1.1.3",
@@ -3328,6 +3252,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -3393,7 +3318,8 @@
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
@@ -5768,11 +5694,11 @@
             }
         },
         "universal-user-agent": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.1.0.tgz",
-            "integrity": "sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+            "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
             "requires": {
-                "os-name": "^3.0.0"
+                "os-name": "^3.1.0"
             }
         },
         "unset-value": {
@@ -5829,11 +5755,6 @@
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
             "dev": true
-        },
-        "url-template": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-            "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
         },
         "use": {
             "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,16 +27,17 @@
     "dependencies": {
         "@actions/core": "^1.1.3",
         "@actions/exec": "^1.0.1",
-        "@actions/github": "^1.1.0",
+        "@actions/github": "^2.0.0",
         "@actions/io": "^1.0.1",
         "@actions/tool-cache": "^1.0.1",
-        "@octokit/graphql": "^2.0.1",
+        "@octokit/graphql": "^4.3.1",
         "@octokit/rest": "^16.35.0",
         "semver": "^6.3.0"
     },
     "devDependencies": {
         "@types/jest": "^24.0.23",
         "@types/node": "^12.12.14",
+        "@types/semver": "^6.2.0",
         "@typescript-eslint/eslint-plugin": "^2.9.0",
         "@typescript-eslint/parser": "^2.9.0",
         "eslint": "^6.7.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
         "noEmitOnError": true,
         "noErrorTruncation": true,
         "noFallthroughCasesInSwitch": true,
-        // TODO: enabling it breaks the `@actions/github` package somehow
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "noImplicitReturns": true,
         "noImplicitThis": true,
         "noUnusedLocals": true,


### PR DESCRIPTION
Updated dependencies now include declaration (`.d.ts`) files that makes it possible to enable `noImplicitAny`.