### PR TITLE
 Add separate tsconfig.eslint.json for tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.eslint.json"
   },
   "plugins": ["@typescript-eslint"],
   "extends": [

--- a/__tests__/input.test.ts
+++ b/__tests__/input.test.ts
@@ -1,0 +1,69 @@
+import { getInput, getInputBool, getInputList } from '../src/input';
+
+describe('input', () => {
+    describe('getInput', () => {
+        it('env.INPUT_FOO | getInput("foo")', () => {
+            process.env['INPUT_FOO'] = '12345';
+            expect(getInput('foo')).toBe('12345');
+        });
+
+        it('env.INPUT_FOO-BAR | getInput("foo-bar")', () => {
+            process.env['INPUT_FOO-BAR'] = '12345';
+            expect(getInput('foo-bar')).toBe('12345');
+        });
+
+        it('env.INPUT_FOO_BAR | getInput("foo-bar")', () => {
+            process.env['INPUT_FOO_BAR'] = '12345';
+            expect(getInput('foo-bar')).toBe('12345');
+        });
+    });
+
+    describe('getInputBool', () => {
+        it('"true" == true', () => {
+            process.env['INPUT_VALUE'] = 'true';
+            expect(getInputBool('value')).toBe(true);
+        });
+
+        it('"1" == true', () => {
+            process.env['INPUT_VALUE'] = '1';
+            expect(getInputBool('value')).toBe(true);
+        });
+
+        it('"" == false', () => {
+            process.env['INPUT_VALUE'] = '';
+            expect(getInputBool('value')).toBe(false);
+        });
+
+        it('"foobar" == false', () => {
+            process.env['INPUT_VALUE'] = 'foobar';
+            expect(getInputBool('value')).toBe(false);
+        });
+    });
+
+    describe('getInputList', () => {
+        it('empty', () => {
+            process.env['INPUT_VALUE'] = '';
+            expect(getInputList('value')).toStrictEqual([]);
+        });
+        it('", ,, "', () => {
+            process.env['INPUT_VALUE'] = ', ,, ';
+            expect(getInputList('value')).toStrictEqual([]);
+        });
+        it('"one,two,three"', () => {
+            process.env['INPUT_VALUE'] = 'one,two,three';
+            expect(getInputList('value')).toStrictEqual([
+                'one',
+                'two',
+                'three',
+            ]);
+        });
+        it('",one , two , three"', () => {
+            process.env['INPUT_VALUE'] = ',one , two , three';
+            expect(getInputList('value')).toStrictEqual([
+                'one',
+                'two',
+                'three',
+            ]);
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,12 +920,6 @@
                 "normalize-path": "^2.1.1"
             }
         },
-        "arg": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
-            "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
-            "dev": true
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1208,6 +1202,15 @@
                     "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
                     "dev": true
                 }
+            }
+        },
+        "bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "requires": {
+                "fast-json-stable-stringify": "2.x"
             }
         },
         "bser": {
@@ -1585,12 +1588,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
             "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-            "dev": true
-        },
-        "diff": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-            "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
             "dev": true
         },
         "diff-sequences": {
@@ -4055,6 +4052,12 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
+        "lodash.memoize": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+            "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+            "dev": true
+        },
         "lodash.set": {
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -5587,17 +5590,45 @@
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
-        "ts-node": {
-            "version": "8.5.4",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-            "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+        "ts-jest": {
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.2.0.tgz",
+            "integrity": "sha512-Yc+HLyldlIC9iIK8xEN7tV960Or56N49MDP7hubCZUeI7EbIOTsas6rXCMB4kQjLACJ7eDOF4xWEO5qumpKsag==",
             "dev": true,
             "requires": {
-                "arg": "^4.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^3.0.0"
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "json5": "2.x",
+                "lodash.memoize": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "0.x",
+                "resolve": "1.x",
+                "semver": "^5.5",
+                "yargs-parser": "10.x"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "yargs-parser": {
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+                    "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    }
+                }
             }
         },
         "tslib": {
@@ -5972,12 +6003,6 @@
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
             }
-        },
-        "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     ],
     "scripts": {
         "build": "tsc -p .",
-        "format": "prettier --write 'src/**/*.{js,ts,tsx}'",
-        "lint": "tsc --noEmit && eslint 'src/**/*.{js,ts,tsx}'",
+        "format": "prettier --write 'src/**/*.ts' '__tests__/**/*.ts'",
+        "lint": "tsc --noEmit && eslint 'src/**/*.ts' '__tests__/**/*.ts'",
         "refresh": "rm -rf ./dist/* && npm run build",
-        "test": "jest --passWithNoTests",
+        "test": "jest -c jest.config.json",
         "watch": "tsc -p . -w"
     },
     "repository": {
@@ -48,7 +48,7 @@
         "jest": "^24.9.0",
         "jest-circus": "^24.9.0",
         "prettier": "^1.19.1",
-        "ts-node": "^8.5.4",
+        "ts-jest": "^24.2.0",
         "typescript": "^3.7.2"
     }
 }

--- a/src/commands/rustup.ts
+++ b/src/commands/rustup.ts
@@ -208,7 +208,7 @@ expected at least ${PROFILES_MIN_VERSION}`);
         let stdout = '';
         const resOptions = Object.assign({}, options, {
             listeners: {
-                stdout: (buffer: Buffer) => {
+                stdout: (buffer: Buffer): void => {
                     stdout += buffer.toString();
                 },
             },

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src/**/*.ts",
+        "__tests__/**/*.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
         "pretty": true,
         "removeComments": true,
         "resolveJsonModule": true,
-        "rootDir": "src",
         "strict": true,
         "suppressImplicitAnyIndexErrors": false,
         "target": "es2018",
@@ -27,6 +26,6 @@
         "sourceMap": true
     },
     "include": [
-        "src"
+        "src/**/*.ts"
     ]
 }


### PR DESCRIPTION
Adds tests for `input.getInput*()`  and some changes to the config to make `eslint` and `jest` actually work with tests in `__tests__`. The `jest.config.json` is not used automatically by jest.

See https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.0.0
> When `project` is specified within `parserOptions`, we will now hard fail when parsing files that are not included within the provided tsconfig(s).
