### PR TITLE
Add GitHub Release installers with fallback to `cargo install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: CI
 on: [pull_request, push]
 jobs:
   # The main CI workflow; installs dependencies, runs eslint, prettier, and jest.
@@ -9,3 +10,26 @@ jobs:
     - run: npm run lint
     - run: npm run build
     - run: npm run test
+
+  installers:
+    name: Test installers
+    needs: [main]
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: npm ci
+      - name: PATH before
+        run: env | grep PATH
+        shell: bash
+      - run: npm run test
+        env:
+          TEST_INSTALLERS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: PATH after
+        run: env | grep PATH
+        shell: bash

--- a/__tests__/commands/cargo.test.ts
+++ b/__tests__/commands/cargo.test.ts
@@ -1,0 +1,52 @@
+import * as io from '@actions/io';
+import { Config, CONFIG } from '../../src/commands/cargo/installer';
+
+describe = process.env.TEST_INSTALLERS === 'true' ? describe : describe.skip;
+
+const CONFIG_WITH_VERSION: [string, string, Config][] = Array.from(CONFIG).map(
+    ([command, config]) => {
+        return [command, config.version, config];
+    },
+);
+
+describe('Test binary installers', () => {
+    it.each(Array.from(CONFIG))(
+        'Install %s@latest',
+        async (command: string, config: Config) => {
+            const { platforms, installer } = config;
+            const t = installer.install('latest');
+
+            if (platforms.includes(process.platform)) {
+                await expect(t).resolves.toBeUndefined();
+                expect(await io.which(command)).toEqual(
+                    expect.stringContaining(command),
+                );
+            } else {
+                const e = new Error(
+                    `Unsupported platform: ${process.platform}`,
+                );
+                await expect(t).rejects.toThrow(e);
+            }
+        },
+    );
+
+    it.each(CONFIG_WITH_VERSION)(
+        'Install %s@%s',
+        async (command, version, config) => {
+            const { platforms, installer } = config;
+            const t = installer.install(version);
+
+            if (platforms.includes(process.platform)) {
+                await expect(t).resolves.toBeUndefined();
+                expect(await io.which(command)).toEqual(
+                    expect.stringContaining(command),
+                );
+            } else {
+                const e = new Error(
+                    `Unsupported platform: ${process.platform}`,
+                );
+                await expect(t).rejects.toThrow(e);
+            }
+        },
+    );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -757,6 +757,46 @@
                 "infer-owner": "^1.0.4"
             }
         },
+        "@octokit/action": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/action/-/action-2.0.0.tgz",
+            "integrity": "sha512-XkZwA1TIYbaliUaKHEV3Riz016tUrTJOzvvPfC4sMfRakXD3VatsJd0ZU8aFWdqi6hfKcfMAD5WRpA4cWpBjRA==",
+            "requires": {
+                "@octokit/auth-action": "^1.2.0",
+                "@octokit/core": "^2.1.1",
+                "@octokit/plugin-paginate-rest": "^2.0.1",
+                "@octokit/plugin-rest-endpoint-methods": "^3.2.0",
+                "@octokit/types": "^2.0.2"
+            },
+            "dependencies": {
+                "@octokit/plugin-paginate-rest": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.0.2.tgz",
+                    "integrity": "sha512-HzODcSUt9mjErly26TlTOGZrhf9bmF/FEDQ2zln1izhgmIV6ulsjsHmgmR4VZ0wzVr/m52Eb6U2XuyS8fkcR1A==",
+                    "requires": {
+                        "@octokit/types": "^2.0.1"
+                    }
+                },
+                "@octokit/plugin-rest-endpoint-methods": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.3.1.tgz",
+                    "integrity": "sha512-iLAXPLWBZaP6ocy1GFfZUCzyN4cwg3y2JE6yZjQo0zLE3UaewC3TI68/TnS4ilyhXDxh81Jr1qwPN1AqTp8t3w==",
+                    "requires": {
+                        "@octokit/types": "^2.0.1",
+                        "deprecation": "^2.3.1"
+                    }
+                }
+            }
+        },
+        "@octokit/auth-action": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-1.2.0.tgz",
+            "integrity": "sha512-AlHcxjGUGIw86FNhEjO+kvNfcSeV1YDrV8BdGgceHCdtbh1DlI3jwsujY4Y2JjIsVpwKaoGQ4mL1s0354SiODA==",
+            "requires": {
+                "@octokit/auth-token": "^2.4.0",
+                "@octokit/types": "^2.0.0"
+            }
+        },
         "@octokit/auth-token": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
@@ -829,46 +869,6 @@
                 "@octokit/request": "^5.3.0",
                 "@octokit/types": "^2.0.0",
                 "universal-user-agent": "^4.0.0"
-            },
-            "dependencies": {
-                "@octokit/endpoint": {
-                    "version": "5.5.1",
-                    "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-                    "integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
-                    "requires": {
-                        "@octokit/types": "^2.0.0",
-                        "is-plain-object": "^3.0.0",
-                        "universal-user-agent": "^4.0.0"
-                    }
-                },
-                "@octokit/request": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-                    "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
-                    "requires": {
-                        "@octokit/endpoint": "^5.5.0",
-                        "@octokit/request-error": "^1.0.1",
-                        "@octokit/types": "^2.0.0",
-                        "deprecation": "^2.0.0",
-                        "is-plain-object": "^3.0.0",
-                        "node-fetch": "^2.3.0",
-                        "once": "^1.4.0",
-                        "universal-user-agent": "^4.0.0"
-                    }
-                },
-                "is-plain-object": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-                    "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-                    "requires": {
-                        "isobject": "^4.0.0"
-                    }
-                },
-                "isobject": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-                    "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-                }
             }
         },
         "@octokit/plugin-paginate-rest": {
@@ -932,18 +932,19 @@
             }
         },
         "@octokit/request-error": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.0.4.tgz",
-            "integrity": "sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+            "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
             "requires": {
+                "@octokit/types": "^2.0.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             }
         },
         "@octokit/rest": {
-            "version": "17.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.1.0.tgz",
-            "integrity": "sha512-L5YtpxHZSHZCh2xETbzxz8clBGmcpT+5e78JLZQ+VfuHrHJ1J/r+R2PGwKHwClUEECTeWFMMdAtIik+OCkANBg==",
+            "version": "17.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.1.1.tgz",
+            "integrity": "sha512-Cn9XpevTJdQj/GbACY1WjArDabPpdAhvlS5zoCdZ/chiKbl4vutL1X1VeJHzDLK0K6BdZXXe4SnEPN31wKPA7A==",
             "requires": {
                 "@octokit/core": "^2.4.0",
                 "@octokit/plugin-paginate-rest": "^2.0.0",
@@ -971,9 +972,9 @@
             }
         },
         "@octokit/types": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.0.1.tgz",
-            "integrity": "sha512-YDYgV6nCzdGdOm7wy43Ce8SQ3M5DMKegB8E5sTB/1xrxOdo2yS/KgUgML2N2ZGD621mkbdrAglwTyA4NDOlFFA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.0.tgz",
+            "integrity": "sha512-KEnLwOfdXzxPNL34fj508bhi9Z9cStyN7qY1kOfVahmqtAfrWw6Oq3P4R+dtsg0lYtZdWBpUrS/Ixmd5YILSww==",
             "requires": {
                 "@types/node": ">= 8"
             }
@@ -1254,21 +1255,6 @@
             "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
             "requires": {
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "agentkeepalive": {
@@ -1279,21 +1265,6 @@
                 "debug": "^4.1.0",
                 "depd": "^1.1.2",
                 "humanize-ms": "^1.2.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "aggregate-error": {
@@ -1351,7 +1322,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
             "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-            "dev": true,
             "requires": {
                 "@types/color-name": "^1.1.1",
                 "color-convert": "^2.0.1"
@@ -1613,46 +1583,10 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
                     "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
                 },
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
                     "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
@@ -1675,14 +1609,6 @@
                     "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
                     "requires": {
                         "ansi-regex": "^5.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1869,7 +1795,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
             "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2037,7 +1962,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -2045,8 +1969,7 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "colors": {
             "version": "1.0.3",
@@ -2061,6 +1984,11 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
         },
         "component-emitter": {
             "version": "1.3.0",
@@ -2084,34 +2012,6 @@
                 "unique-string": "^2.0.0",
                 "write-file-atomic": "^3.0.0",
                 "xdg-basedir": "^4.0.0"
-            },
-            "dependencies": {
-                "make-dir": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-                    "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
-                    "requires": {
-                        "semver": "^6.0.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                        }
-                    }
-                },
-                "write-file-atomic": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-                    "requires": {
-                        "imurmurhash": "^0.1.4",
-                        "is-typedarray": "^1.0.0",
-                        "signal-exit": "^3.0.2",
-                        "typedarray-to-buffer": "^3.1.5"
-                    }
-                }
             }
         },
         "convert-source-map": {
@@ -2218,7 +2118,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             },
@@ -2226,8 +2125,7 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
             }
         },
@@ -2937,11 +2835,12 @@
             }
         },
         "find-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "requires": {
-                "locate-path": "^3.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
             }
         },
         "flat-cache": {
@@ -3146,9 +3045,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-            "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+            "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
         },
         "growly": {
             "version": "1.3.0",
@@ -3200,8 +3099,7 @@
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -3266,6 +3164,14 @@
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
         },
+        "hosted-git-info": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
+            "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
+            "requires": {
+                "lru-cache": "^5.1.1"
+            }
+        },
         "html-encoding-sniffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -3294,21 +3200,6 @@
                 "@tootallnate/once": "1",
                 "agent-base": "6",
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "http-signature": {
@@ -3329,21 +3220,6 @@
             "requires": {
                 "agent-base": "6",
                 "debug": "4"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "human-signals": {
@@ -4473,7 +4349,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
             "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
-            "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
             },
@@ -4481,8 +4356,7 @@
                 "minimist": {
                     "version": "1.2.5",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                    "dev": true
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
                 }
             }
         },
@@ -4554,15 +4428,46 @@
                 "figgy-pudding": "^3.5.1",
                 "find-up": "^3.0.0",
                 "ini": "^1.3.5"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
             }
         },
         "locate-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "^4.1.0"
             }
         },
         "lodash": {
@@ -4628,7 +4533,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
             "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
-            "dev": true,
             "requires": {
                 "semver": "^6.0.0"
             },
@@ -4636,8 +4540,7 @@
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
                 }
             }
         },
@@ -5059,108 +4962,10 @@
                 "update-notifier": "^4.1.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "commander": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-                    "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
-                },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
                 "get-stdin": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
                     "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "requires": {
-                        "p-locate": "^4.1.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-                },
-                "prompts": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-                    "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
-                    "requires": {
-                        "kleur": "^3.0.3",
-                        "sisteransi": "^1.0.4"
-                    }
-                },
-                "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
-                },
-                "sisteransi": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-                    "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
                 }
             }
         },
@@ -5170,13 +4975,6 @@
             "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
             "requires": {
                 "semver": "^7.1.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
-                }
             }
         },
         "npm-normalize-package-bin": {
@@ -5192,21 +4990,6 @@
                 "hosted-git-info": "^3.0.2",
                 "semver": "^7.0.0",
                 "validate-npm-package-name": "^3.0.0"
-            },
-            "dependencies": {
-                "hosted-git-info": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
-                    "integrity": "sha512-4oT62d2jwSDBbLLFLZE+1vPuQ1h8p9wjrJ8Mqx5TjsyWmBMV5B13eJqn8pvluqubLf3cJPTfiYCIwNwDNmzScQ==",
-                    "requires": {
-                        "lru-cache": "^5.1.1"
-                    }
-                },
-                "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
-                }
             }
         },
         "npm-packlist": {
@@ -5243,13 +5026,6 @@
                 "npm-install-checks": "^4.0.0",
                 "npm-package-arg": "^8.0.0",
                 "semver": "^7.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
-                }
             }
         },
         "npm-registry-fetch": {
@@ -5446,11 +5222,11 @@
             }
         },
         "p-locate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "requires": {
-                "p-limit": "^2.0.0"
+                "p-limit": "^2.2.0"
             }
         },
         "p-map": {
@@ -5519,11 +5295,6 @@
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
                     "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
                 },
-                "semver": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-                    "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
-                },
                 "which": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5556,9 +5327,9 @@
             "dev": true
         },
         "path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -5727,7 +5498,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
             "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
-            "dev": true,
             "requires": {
                 "kleur": "^3.0.3",
                 "sisteransi": "^1.0.4"
@@ -5795,34 +5565,6 @@
                 "js-yaml": "^3.12.0",
                 "json5": "^2.1.1",
                 "require-from-string": "^2.0.2"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "json5": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-                    "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "react-is": {
@@ -6391,8 +6133,7 @@
         "sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-            "dev": true
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
         },
         "slash": {
             "version": "3.0.0",
@@ -6581,21 +6322,6 @@
                 "agent-base": "6",
                 "debug": "4",
                 "socks": "^2.3.3"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "source-map": {
@@ -6793,7 +6519,6 @@
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
             "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-            "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }
@@ -7124,9 +6849,9 @@
             }
         },
         "universal-user-agent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-            "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+            "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
             "requires": {
                 "os-name": "^3.1.0"
             }
@@ -7189,52 +6914,6 @@
                 "pupa": "^2.0.1",
                 "semver-diff": "^3.1.1",
                 "xdg-basedir": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-                    "requires": {
-                        "@types/color-name": "^1.1.1",
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "chalk": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
             }
         },
         "uri-js": {
@@ -7533,7 +7212,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
             "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-            "dev": true,
             "requires": {
                 "imurmurhash": "^0.1.4",
                 "is-typedarray": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@actions/github": "^2.1.1",
         "@actions/io": "^1.0.2",
         "@actions/tool-cache": "^1.3.3",
+        "@octokit/action": "^2.0.0",
         "@octokit/graphql": "^4.3.1",
         "@octokit/rest": "^17.1.0",
         "npm-check-updates": "^4.0.4",

--- a/src/commands/cargo.ts
+++ b/src/commands/cargo.ts
@@ -1,6 +1,7 @@
 import * as io from '@actions/io';
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
+import Installers from './cargo/installer';
 
 export class Cargo {
     private readonly path: string;
@@ -52,16 +53,9 @@ see https://help.github.com/en/articles/software-in-virtual-environments-for-git
         program: string,
         version?: string,
     ): Promise<string> {
-        const args = ['install'];
-        if (version && version != 'latest') {
-            args.push('--version');
-            args.push(version);
-        }
-        args.push(program);
-
         try {
             core.startGroup(`Installing "${program} = ${version || 'latest'}"`);
-            await this.call(args);
+            await Installers.get(this, program).install(version);
         } finally {
             core.endGroup();
         }

--- a/src/commands/cargo/cargo-make.ts
+++ b/src/commands/cargo/cargo-make.ts
@@ -1,0 +1,66 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as tc from '@actions/tool-cache';
+import { Config, Installer, Task, getLatestRelease } from './installer';
+
+async function resolveVersion(value?: string): Promise<string> {
+    if (value === 'latest' || value === undefined) {
+        return await getLatestRelease('sagiegurari', 'cargo-make');
+    }
+    return Promise.resolve(value);
+}
+
+class CargoMakeInstaller implements Installer {
+    async install(version?: string): Task {
+        version = await resolveVersion(version);
+
+        let arch = '';
+        let archFolder = '';
+        switch (process.platform) {
+            case 'linux':
+                arch = 'x86_64-unknown-linux-musl';
+                archFolder = `cargo-make-v${version}-${arch}`;
+                break;
+            case 'darwin':
+                arch = 'x86_64-apple-darwin';
+                archFolder = `cargo-make-v${version}-${arch}`;
+                break;
+            case 'win32':
+                arch = 'x86_64-pc-windows-msvc';
+                break;
+            default:
+                throw Error(`Unsupported platform: ${process.platform}`);
+        }
+
+        const tmpFolder = path.join(os.tmpdir(), `setup-cargo-make-${version}`);
+        await io.mkdirP(tmpFolder);
+
+        const archive = `cargo-make-v${version}-${arch}`;
+        const cacheKey = `cargo-make-${process.platform}`;
+        const url = `https://github.com/sagiegurari/cargo-make/releases/download/${version}/${archive}.zip`;
+
+        let binPath = tc.find(cacheKey, version);
+        if (!binPath) {
+            const downloaded = await tc.downloadTool(url);
+            const extracted = await tc.extractZip(downloaded, tmpFolder);
+            const cachePath = path.join(extracted, archFolder);
+
+            binPath = await tc.cacheDir(cachePath, cacheKey, version);
+        }
+        core.addPath(binPath);
+    }
+}
+
+export function config(): [string, Config] {
+    return [
+        'cargo-make',
+        {
+            command: 'cargo-make',
+            version: '0.24.3',
+            platforms: ['linux', 'darwin', 'win32'],
+            installer: new CargoMakeInstaller(),
+        },
+    ];
+}

--- a/src/commands/cargo/cargo-tarpaulin.ts
+++ b/src/commands/cargo/cargo-tarpaulin.ts
@@ -1,0 +1,58 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as tc from '@actions/tool-cache';
+import { Config, Installer, Task, getLatestRelease } from './installer';
+
+async function resolveVersion(value?: string): Promise<string> {
+    if (value === 'latest' || value === undefined) {
+        return await getLatestRelease('xd009642', 'tarpaulin');
+    }
+    return Promise.resolve(value);
+}
+
+export class TarpaulinInstaller implements Installer {
+    async install(version?: string): Task {
+        version = await resolveVersion(version);
+
+        let archive = '';
+        switch (process.platform) {
+            case 'linux':
+                archive = `cargo-tarpaulin-${version}-travis`;
+                break;
+            default:
+                throw Error(`Unsupported platform: ${process.platform}`);
+        }
+
+        const tmpFolder = path.join(
+            os.tmpdir(),
+            `setup-cargo-tarpaulin-${version}`,
+        );
+        await io.mkdirP(tmpFolder);
+
+        const cacheKey = `cargo-tarpaulin-${process.platform}`;
+        const url = `https://github.com/xd009642/tarpaulin/releases/download/${version}/${archive}.tar.gz`;
+
+        let binPath = tc.find(cacheKey, version);
+        if (!binPath) {
+            const downloaded = await tc.downloadTool(url);
+            const extracted = await tc.extractTar(downloaded, tmpFolder);
+
+            binPath = await tc.cacheDir(extracted, cacheKey, version);
+        }
+        core.addPath(binPath);
+    }
+}
+
+export function config(): [string, Config] {
+    return [
+        'cargo-tarpaulin',
+        {
+            command: 'cargo-tarpaulin',
+            version: '0.9.3',
+            platforms: ['linux'],
+            installer: new TarpaulinInstaller(),
+        },
+    ];
+}

--- a/src/commands/cargo/cargo-web.ts
+++ b/src/commands/cargo/cargo-web.ts
@@ -1,0 +1,67 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as exec from '@actions/exec';
+import * as io from '@actions/io';
+import * as tc from '@actions/tool-cache';
+import { Config, Installer, Task, getLatestRelease } from './installer';
+
+async function resolveVersion(value?: string): Promise<string> {
+    if (value === 'latest' || value === undefined) {
+        return await getLatestRelease('koute', 'cargo-web');
+    }
+    return Promise.resolve(value);
+}
+
+class CargoWebInstaller implements Installer {
+    async install(version?: string): Task {
+        version = await resolveVersion(version);
+
+        let arch = '';
+        switch (process.platform) {
+            case 'linux':
+                arch = 'x86_64-unknown-linux-gnu';
+                break;
+            case 'darwin':
+                arch = 'x86_64-apple-darwin';
+                break;
+            default:
+                throw Error(`Unsupported platform: ${process.platform}`);
+        }
+
+        const tmpFolder = path.join(os.tmpdir(), `setup-cargo-web-${version}`);
+        await io.mkdirP(tmpFolder);
+
+        const archive = `cargo-web-${arch}`;
+        const cacheKey = `cargo-web-${process.platform}`;
+        const url = `https://github.com/koute/cargo-web/releases/download/${version}/${archive}.gz`;
+
+        let binPath = tc.find(cacheKey, version);
+        if (!binPath) {
+            const downloaded = await tc.downloadTool(url);
+            await io.mv(downloaded, `${downloaded}.gz`);
+            await exec.exec(`gzip -d ${downloaded}`);
+            await exec.exec(`chmod +x ${downloaded}`);
+
+            binPath = await tc.cacheFile(
+                downloaded,
+                'cargo-web',
+                cacheKey,
+                version,
+            );
+        }
+        core.addPath(binPath);
+    }
+}
+
+export function config(): [string, Config] {
+    return [
+        'cargo-web',
+        {
+            command: 'cargo-web',
+            version: '0.6.25',
+            platforms: ['linux', 'darwin'],
+            installer: new CargoWebInstaller(),
+        },
+    ];
+}

--- a/src/commands/cargo/grcov.ts
+++ b/src/commands/cargo/grcov.ts
@@ -26,9 +26,9 @@ class GrcovInstaller implements Installer {
             case 'darwin':
                 arch = 'osx-x86_64';
                 break;
-            case 'win32':
-                arch = 'win-x86_64';
-                break;
+            // case 'win32':
+            //     arch = 'win-x86_64';
+            //     break;
             default:
                 throw Error(`Unsupported platform: ${process.platform}`);
         }
@@ -57,7 +57,7 @@ export function config(): [string, Config] {
         {
             command: 'grcov',
             version: '0.5.6',
-            platforms: ['linux', 'darwin', 'win32'],
+            platforms: ['linux', 'darwin' /*, 'win32'*/],
             installer: new GrcovInstaller(),
         },
     ];

--- a/src/commands/cargo/grcov.ts
+++ b/src/commands/cargo/grcov.ts
@@ -1,0 +1,64 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as semver from 'semver';
+import * as tc from '@actions/tool-cache';
+import { Config, Installer, Task, getLatestRelease } from './installer';
+
+async function resolveVersion(value?: string): Promise<string> {
+    if (value === 'latest' || value === undefined) {
+        return await getLatestRelease('mozilla', 'grcov');
+    }
+    value = 'v' + semver.coerce(value);
+    return Promise.resolve(value);
+}
+
+class GrcovInstaller implements Installer {
+    async install(version?: string): Task {
+        version = await resolveVersion(version);
+
+        let arch = '';
+        switch (process.platform) {
+            case 'linux':
+                arch = 'linux-x86_64';
+                break;
+            case 'darwin':
+                arch = 'osx-x86_64';
+                break;
+            case 'win32':
+                arch = 'win-x86_64';
+                break;
+            default:
+                throw Error(`Unsupported platform: ${process.platform}`);
+        }
+
+        const tmpFolder = path.join(os.tmpdir(), `setup-grcov-${version}`);
+        await io.mkdirP(tmpFolder);
+
+        const archive = `grcov-${arch}`;
+        const cacheKey = `grcov-${process.platform}`;
+        const url = `https://github.com/mozilla/grcov/releases/download/${version}/${archive}.tar.bz2`;
+
+        let binPath = tc.find(cacheKey, version);
+        if (!binPath) {
+            const downloaded = await tc.downloadTool(url);
+            const extracted = await tc.extractTar(downloaded, tmpFolder, 'xj');
+
+            binPath = await tc.cacheDir(extracted, cacheKey, version);
+        }
+        core.addPath(binPath);
+    }
+}
+
+export function config(): [string, Config] {
+    return [
+        'grcov',
+        {
+            command: 'grcov',
+            version: '0.5.6',
+            platforms: ['linux', 'darwin', 'win32'],
+            installer: new GrcovInstaller(),
+        },
+    ];
+}

--- a/src/commands/cargo/installer.ts
+++ b/src/commands/cargo/installer.ts
@@ -1,0 +1,101 @@
+import * as core from '@actions/core';
+import { Octokit } from '@octokit/action';
+import { Cargo } from '../cargo';
+import * as cargoMake from './cargo-make';
+import * as cargoTarpaulin from './cargo-tarpaulin';
+import * as cargoWeb from './cargo-web';
+import * as grcov from './grcov';
+import * as mdbook from './mdbook';
+
+export type Task = Promise<void>;
+
+export interface Installer {
+    install(version?: string): Task;
+}
+
+export interface Config {
+    command: string;
+    version: string;
+    platforms: string[];
+    installer: Installer;
+}
+
+class CargoInstaller implements Installer {
+    cargo: Cargo;
+    program: string;
+
+    constructor(cargo: Cargo, program: string) {
+        this.cargo = cargo;
+        this.program = program;
+    }
+
+    async install(version?: string): Task {
+        const args = ['install'];
+        if (version && version != 'latest') {
+            args.push('--version');
+            args.push(version);
+        }
+        args.push(this.program);
+
+        await this.cargo.call(args);
+    }
+}
+
+class FallbackInstaller implements Installer {
+    installer: Installer;
+    cargo: Installer;
+
+    constructor(installer: Installer, cargo: Installer) {
+        this.installer = installer;
+        this.cargo = cargo;
+    }
+
+    async install(version?: string): Task {
+        try {
+            await this.installer.install(version);
+        } catch (error) {
+            core.error(
+                `Downloading the binary release failed: ${error.message}`,
+            );
+            core.error('Fallback to `cargo install`');
+            await this.cargo.install(version);
+        }
+    }
+}
+
+// Force unauthenticated when no GitHub token is provided.
+const GitHub = Octokit.defaults(
+    process.env.GITHUB_TOKEN !== undefined ? {} : { authStrategy: undefined },
+);
+
+export async function getLatestRelease(
+    owner: string,
+    repo: string,
+): Promise<string> {
+    const github = new GitHub();
+    const { data: release } = await github.repos.getLatestRelease({
+        owner,
+        repo,
+    });
+    return release.tag_name;
+}
+
+export const CONFIG = new Map([
+    cargoMake.config(),
+    cargoTarpaulin.config(),
+    cargoWeb.config(),
+    grcov.config(),
+    mdbook.config(),
+]);
+
+export default class Installers {
+    static get(cargo: Cargo, program: string): Installer {
+        const platform = process.platform;
+        const config = CONFIG.get(program);
+        const installer = new CargoInstaller(cargo, program);
+        if (config && config.platforms.includes(platform)) {
+            return new FallbackInstaller(config.installer, installer);
+        }
+        return installer;
+    }
+}

--- a/src/commands/cargo/mdbook.ts
+++ b/src/commands/cargo/mdbook.ts
@@ -1,0 +1,71 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as semver from 'semver';
+import * as tc from '@actions/tool-cache';
+import { Config, Installer, Task, getLatestRelease } from './installer';
+
+async function resolveVersion(value?: string): Promise<string> {
+    if (value === 'latest' || value === undefined) {
+        return await getLatestRelease('rust-lang', 'mdBook');
+    }
+    value = 'v' + semver.coerce(value);
+    return Promise.resolve(value);
+}
+
+class MdbookInstaller implements Installer {
+    async install(version?: string): Task {
+        version = await resolveVersion(version);
+
+        let arch = '';
+        let archExt = '.tar.gz';
+        switch (process.platform) {
+            case 'linux':
+                arch = 'x86_64-unknown-linux-gnu';
+                break;
+            case 'darwin':
+                arch = 'x86_64-apple-darwin';
+                break;
+            case 'win32':
+                arch = 'x86_64-pc-windows-msvc';
+                archExt = '.zip';
+                break;
+            default:
+                throw Error(`Unsupported platform: ${process.platform}`);
+        }
+
+        const tmpFolder = path.join(os.tmpdir(), `setup-mdbook-${version}`);
+        await io.mkdirP(tmpFolder);
+
+        const archive = `mdbook-${version}-${arch}`;
+        const cacheKey = `mdbook-${process.platform}`;
+        const url = `https://github.com/rust-lang/mdBook/releases/download/${version}/${archive}${archExt}`;
+
+        let binPath = tc.find(cacheKey, version);
+        if (!binPath) {
+            const downloaded = await tc.downloadTool(url);
+            let extracted;
+            if (process.platform == 'win32') {
+                extracted = await tc.extractZip(downloaded, tmpFolder);
+            } else {
+                extracted = await tc.extractTar(downloaded, tmpFolder);
+            }
+
+            binPath = await tc.cacheDir(extracted, cacheKey, version);
+        }
+        core.addPath(binPath);
+    }
+}
+
+export function config(): [string, Config] {
+    return [
+        'mdbook',
+        {
+            command: 'mdbook',
+            version: '0.3.4',
+            platforms: ['linux', 'darwin', 'win32'],
+            installer: new MdbookInstaller(),
+        },
+    ];
+}


### PR DESCRIPTION
The PR adds GitHub Release installers for several projects.
* cargo-make [linux, darwin, win32]
* cargo-tarpaulin [linux]
* cargo-web [linux, darwin]
* grcov [linux, darwin, ~~win32~~]
* mdbook [linux, darwin, win32]

If an installer fails then the `CargoInstaller` will be used to install the command via `cargo install`.

It's advisable to set the `GITHUB_TOKEN` env var when installing the **latest** version  because the installers fetch the latest GitHub Release information and could hit the **API rate limit** for the current runner.

The `grcov` installer is disabled for windows because the grcov tests hang on windows and i couldn't find the reason yet.

related: #31 


