### PR TITLE
Use GitHub Actions cache in installCached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,27 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@actions/cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-0.2.1.tgz",
+            "integrity": "sha512-CV2D9zp+d+nL7o6XK/I7vVh350JglPMp/jHi9ppRUkdBHPUeP0UHVUfygZaAs8WmxhhWY1MI0gWah+t0QYu3Fg==",
+            "requires": {
+                "@actions/core": "^1.2.4",
+                "@actions/exec": "^1.0.1",
+                "@actions/glob": "^0.1.0",
+                "@actions/http-client": "^1.0.8",
+                "@actions/io": "^1.0.1",
+                "semver": "^6.1.0",
+                "uuid": "^3.3.3"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "@actions/core": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
@@ -68,6 +89,15 @@
                         "os-name": "^3.1.0"
                     }
                 }
+            }
+        },
+        "@actions/glob": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@actions/glob/-/glob-0.1.0.tgz",
+            "integrity": "sha512-lx8SzyQ2FE9+UUvjqY1f28QbTJv+w8qP7kHHbfQRhphrlcx0Mdmm1tZdGJzfxv1jxREa/sLW4Oy8CbGQKCJySA==",
+            "requires": {
+                "@actions/core": "^1.2.0",
+                "minimatch": "^3.0.4"
             }
         },
         "@actions/http-client": {
@@ -1771,8 +1801,7 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
             "version": "0.11.2",
@@ -1863,7 +1892,6 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2229,8 +2257,7 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
             "version": "5.0.1",
@@ -5625,7 +5652,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "url": "https://github.com/actions-rs/core/issues"
     },
     "dependencies": {
+        "@actions/cache": "^0.2.1",
         "@actions/core": "^1.2.4",
         "@actions/exec": "^1.0.4",
         "@actions/github": "^2.2.0",

--- a/src/input.ts
+++ b/src/input.ts
@@ -41,3 +41,13 @@ export function getInputList(
         .map((item: string) => item.trim())
         .filter((item: string) => item.length > 0);
 }
+
+export function getInputAsArray(
+    name: string,
+    options?: core.InputOptions,
+): string[] {
+    return getInput(name, options)
+        .split('\n')
+        .map((s) => s.trim())
+        .filter((x) => x !== '');
+}


### PR DESCRIPTION
Fixes #31 

This doesn't use tool-cache, like mentioned in the issue, but rather the GitHub Actions cache directly.

For easier review, I'll comment some of the code changes.

This is the first time I'm writing TS code ever, so I'm not confident that this is the right way to do it. I think the version of this package has to be bumped after merging this PR.

This change has to be merged together with/before actions-rs/install#5

I tested this in my GHA test repo:

Workflow run where RTIM has to be build: https://github.com/flip1995/gha_playground/runs/807533735?check_suite_focus=true
Workflow run where RTIM was already chached: https://github.com/flip1995/gha_playground/runs/807555956?check_suite_focus=true