### PR TITLE
Fix rustup download & installation on Windows

### DIFF
--- a/src/commands/rustup.ts
+++ b/src/commands/rustup.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import * as process from 'process';
+import * as os from 'os';
 
 import * as semver from 'semver';
 import * as io from '@actions/io';
@@ -73,8 +74,11 @@ export class RustUp {
             }
 
             case 'win32': {
+                const downloadPath = path.join(os.tmpdir(), "rustup-init.exe");
+                await fs.rm(downloadPath, { force: true });
                 const rustupExe = await tc.downloadTool(
                     'https://win.rustup.rs',
+                    downloadPath,
                 );
                 await exec.exec(rustupExe, args);
                 break;


### PR DESCRIPTION
When downloading the rustup-init binary for installation on Windows it should be named rustup-init.exe in order to be executable on the runner. If not it fails with the following error:

```
Error: Unable to locate executable file: D:\a\_temp\27bbd22a-fb15-4983-b256-c980efbc05b8. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.
```

The issue is locally reproducible on master through this test (run on Windows):
```
import { RustUp } from '../src/commands/rustup';

test('RustupGetOrInstall', async () => {
    process.env.RUNNER_TEMP = '_temp';
    await jest.setTimeout(10000);
    await expect(RustUp.getOrInstall()).resolves.toBeDefined();
});
```

I believe the issue hasn't turned up so far since the GitHub-hosted Windows runners already have rustup installed so `RustUp.getOrInstall()` has never hit the install phase. I came across this while using a self-hosted runner. See this [failed build that first uninstalls rustup before running actions-rs/toolchain](https://github.com/lionel1704/safe_network/runs/4688347548?check_suite_focus=true#step:3:19)

The test is long-running (depending on internet speed - for the download) so a shaky network causes it to fail. So I didn't add it to the suite.

Credits to @TingluoHuang for pointing me in the right direction.